### PR TITLE
fix(exporter): Set dielectric PBR defaults for GLB without ORM texture

### DIFF
--- a/sdfstudio/exporter/texture_utils_v2.py
+++ b/sdfstudio/exporter/texture_utils_v2.py
@@ -856,6 +856,14 @@ def write_textured_mesh_fast(
         except Exception:  # pylint: disable=broad-exception-caught
             material = None
 
+    # Set dielectric defaults when no ORM texture is provided. PBRMaterial defaults
+    # metallicFactor to 1.0 which makes non-PBR exports look wrong in viewers.
+    if material is not None and orm_image is None:
+        if hasattr(material, "metallicFactor"):
+            material.metallicFactor = 0.0
+        if hasattr(material, "roughnessFactor"):
+            material.roughnessFactor = 1.0
+
     if material is None:
         material = trimesh.visual.material.SimpleMaterial(  # type: ignore
             image=texture_pil,


### PR DESCRIPTION
## Summary

Fix GLB export showing fully metallic appearance when no PBR metallic/roughness texture is provided.

## Changes

- Set `metallicFactor=0.0` and `roughnessFactor=1.0` as defaults when `orm_image` is None
- Applies to `write_textured_mesh_fast()` in `sdfstudio/exporter/texture_utils_v2.py`

## Type of Change

- [x] Bug fix

## Testing

- Verified with pyright/ruff (passes)
- Manual: GLB exports without ORM texture should now appear as dielectric (non-metallic) in viewers

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.ai/code)