### PR TITLE
fix: resample training images in FlexibleDataManager

### DIFF
--- a/sdfstudio/data/datamanagers/base_datamanager.py
+++ b/sdfstudio/data/datamanagers/base_datamanager.py
@@ -485,7 +485,13 @@ class FlexibleDataManagerConfig(VanillaDataManagerConfig):
     _target: type = field(default_factory=lambda: FlexibleDataManager)
     """Target class to instantiate."""
     train_num_images_to_sample_from: int = 1
-    """Number of images to sample during training iteration."""
+    """Number of images to sample during training iteration. Forced to 1 because
+    ``FlexibleDataManager.next_train`` builds each batch from a single reference image
+    plus its source views."""
+    train_num_times_to_repeat_images: int = 0
+    """Resample a new training image every iteration. The inherited default of -1
+    (never resample) would cache the single sampled image once and overfit it, since
+    ``train_num_images_to_sample_from`` is 1."""
 
 
 class FlexibleDataManager(VanillaDataManager):

--- a/sdfstudio/data/utils/dataloaders.py
+++ b/sdfstudio/data/utils/dataloaders.py
@@ -82,7 +82,9 @@ class CacheDataloader(DataLoader):
             self.cached_collated_batch = self._get_collated_batch()
         elif self.num_times_to_repeat_images == -1:
             CONSOLE.print(
-                f"Caching {self.num_images_to_sample_from} out of {len(self.dataset)} images, without resampling."
+                f"[bold yellow]Warning: Caching {self.num_images_to_sample_from} out of {len(self.dataset)} images "
+                "without resampling (num_times_to_repeat_images=-1); the remaining images will never be seen during "
+                "training. Set num_times_to_repeat_images >= 0 to rotate through all images."
             )
         else:
             CONSOLE.print(

--- a/tests/data/test_dataloaders.py
+++ b/tests/data/test_dataloaders.py
@@ -1,0 +1,62 @@
+"""Tests for the training image resampling behaviour of ``CacheDataloader``.
+
+Regression coverage for the ``FlexibleDataManagerConfig`` default that used to cache a
+single training image forever (see issue #18).
+"""
+
+from __future__ import annotations
+
+import random
+
+import torch
+from torch.utils.data import Dataset
+
+from sdfstudio.data.datamanagers.base_datamanager import FlexibleDataManagerConfig
+from sdfstudio.data.utils.dataloaders import CacheDataloader
+
+
+class _IndexDataset(Dataset):
+    """Minimal dataset returning its item index, enough to exercise CacheDataloader."""
+
+    def __init__(self, num_images: int) -> None:
+        self.num_images = num_images
+
+    def __len__(self) -> int:
+        return self.num_images
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        return {"image_idx": torch.tensor(idx)}
+
+
+def _sampled_indices(dataloader: CacheDataloader, num_iters: int) -> list[int]:
+    iterator = iter(dataloader)
+    return [int(next(iterator)["image_idx"].item()) for _ in range(num_iters)]
+
+
+def test_never_resample_caches_single_image() -> None:
+    """With num_times_to_repeat_images=-1 the same image is served forever."""
+    random.seed(0)
+    dataloader = CacheDataloader(
+        _IndexDataset(num_images=5),
+        num_images_to_sample_from=1,
+        num_times_to_repeat_images=-1,
+    )
+    assert len(set(_sampled_indices(dataloader, num_iters=50))) == 1
+
+
+def test_resample_every_iteration_rotates_images() -> None:
+    """With num_times_to_repeat_images=0 a new image is resampled each iteration."""
+    random.seed(0)
+    dataloader = CacheDataloader(
+        _IndexDataset(num_images=5),
+        num_images_to_sample_from=1,
+        num_times_to_repeat_images=0,
+    )
+    assert len(set(_sampled_indices(dataloader, num_iters=50))) > 1
+
+
+def test_flexible_datamanager_resamples_by_default() -> None:
+    """The Flexible config must resample so it does not overfit a single image."""
+    config = FlexibleDataManagerConfig()
+    assert config.train_num_images_to_sample_from == 1
+    assert config.train_num_times_to_repeat_images == 0


### PR DESCRIPTION
## Summary

`FlexibleDataManagerConfig` forces `train_num_images_to_sample_from=1` but inherits `train_num_times_to_repeat_images=-1` from `VanillaDataManagerConfig`. In `CacheDataloader` that combination caches one randomly chosen training image at startup and never resamples another, so any method on this config trains against a single view. Affected methods: `geo-neus`, `geo-volsdf`, `geo-unisurf`.

Closes: #18

## Changes

- Default `FlexibleDataManagerConfig.train_num_times_to_repeat_images` to `0`, so a new single image is resampled every iteration instead of caching one forever.
- Document why `train_num_images_to_sample_from` is pinned to 1 (each batch is one reference image plus its source views in `FlexibleDataManager.next_train`).
- Turn the `CacheDataloader` "without resampling" message into a warning, so the same footgun is loud for any other config that sets `num_times_to_repeat_images=-1` with a subset of images.
- Add `tests/data/test_dataloaders.py` covering the resampling behaviour and the corrected config default.

## Type of Change

- [x] Bug fix

## Testing

- [ ] Ran `sdf-dev-test` (required)
- [x] Added/updated tests
- [ ] Tested training manually

Ran on the changed files (full `sdf-dev-test` blocked locally by the `tinycudann` GPU build):

- `uv run --no-sync ruff format --check` + `ruff check` — pass
- `uv run --no-sync pyright sdfstudio/...` — 0 errors
- `uv run --no-sync pytest tests/data/test_dataloaders.py` — 3 passed

## Checklist

- [x] My code follows the existing style (ruff format + pyright)
- [ ] I have updated documentation if needed
